### PR TITLE
Music overlay enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All music commands use the `!request` prefix:
 | `!request play` | `!play` | Mods | Start playback or resume from pause |
 | `!request pause` | `!pause` | Mods | Pause the current track |
 | `!request resume` | `!resume` | Mods | Resume the current track |
-| `!request skip` / `done` | `!skip` / `!done` | Mods | Skip the current track |
+| `!request skip` / `done` | `!skip` / `!done` | Mods | Skip the current track (automatically plays the next track if autoplay is enabled) |
 | `!request limit` | `!limit` | Mods | Toggle rate limiting on/off |
 | `!request autoplay` | `!autoplay` | Mods | Toggle autoplaying the next song in the queue |
 
@@ -49,13 +49,25 @@ All music commands use the `!request` prefix:
 | `!poll` / `!getPoll` | Everyone | Shows the results of the currently active Twitch poll |
 | `!poll <question> // <choice 1> // <choice 2>` | Everyone | Creates a new Twitch poll with channel points voting (max 6 choices) |
 
-### Music OBS Overlay Setup
+### Music OBS Overlays Setup
 
-1. Add a **Browser Source** in OBS
-2. Set the URL to `http://localhost:38080/music`
-3. Set the dimensions to **490 × 120**
-4. The overlay has a transparent background — position it wherever you like on your scene
-5. Make sure **"Control audio via OBS"** is configured to your preference (the YouTube player audio comes through the browser source)
+The bot provides two distinct browser overlays for music:
+
+**1. Mini Player & Audio Source (Required)**
+This is the main player that handles the audio and displays a small "Now Playing" widget.
+- Add a **Browser Source** in OBS
+- Set the URL to `http://localhost:38080/music`
+- Set the dimensions to **490 × 120**
+- The overlay has a transparent background — position it wherever you like on your scene
+- Make sure **"Control audio via OBS"** is configured to your preference (the YouTube player audio comes through the browser source)
+
+**2. Full-Screen "Now Playing" Splash (Optional)**
+This overlay stays 100% transparent but displays a large, centered splash screen with the album art and track info for 3 seconds whenever a new song starts playing. Note: The audio in the Mini Player is intentionally delayed by 4 seconds to allow this splash screen animation to finish gracefully.
+- Add a **Browser Source** in OBS
+- Set the URL to `http://localhost:38080/nowplaying`
+- Set the dimensions to match your stream output (e.g., **1920 × 1080**)
+- Place it above your game capture, but behind critical alerts
+- **Opacity Tweak**: To adjust how transparent this overlay is, add `opacity: 0.9;` (or your preferred value) to the OBS browser source's Custom CSS field within the `body { ... }` block.
 
 ## Donorbox Overlay Setup
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All music commands use the `!request` prefix:
 | `!request resume` | Mods | Resume the current track |
 | `!request skip` / `done` | Mods | Skip the current track |
 | `!request limit` | Mods | Toggle rate limiting on/off |
+| `!request autoplay` | Mods | Toggle autoplaying the next song in the queue |
 
 ### General Chat Commands
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Go-powered Twitch chatbot with a music request system and OBS browser overlay.
 4. The overlay connects via WebSocket and receives real-time state updates (current track, queue, pause state)
 5. The YouTube IFrame API plays audio in the browser source — OBS captures the audio output
 
-### Chat Commands
+### Music Request Commands
 
 All music commands use the `!request` prefix:
 
@@ -37,13 +37,33 @@ All music commands use the `!request` prefix:
 | `!request skip` / `done` | Mods | Skip the current track |
 | `!request limit` | Mods | Toggle rate limiting on/off |
 
-### OBS Overlay Setup
+### General Chat Commands
+
+| Command | Who | Description |
+|---------|-----|-------------|
+| `!hello` / `!hellobot` | Everyone | Greets the user |
+| `!bye` / `!byebot` | Everyone | Says goodbye to the user |
+| `!quote` / `!randomquote` | Everyone | Displays a random Zen quote with a twist |
+| `!abc <message>` / `!alpha <message>` | Everyone | Alphabetizes the words in your message |
+| `!poll` / `!getPoll` | Everyone | Shows the results of the currently active Twitch poll |
+| `!poll <question> // <choice 1> // <choice 2>` | Everyone | Creates a new Twitch poll with channel points voting (max 6 choices) |
+
+### Music OBS Overlay Setup
 
 1. Add a **Browser Source** in OBS
 2. Set the URL to `http://localhost:38080/music`
 3. Set the dimensions to **490 × 120**
 4. The overlay has a transparent background — position it wherever you like on your scene
 5. Make sure **"Control audio via OBS"** is configured to your preference (the YouTube player audio comes through the browser source)
+
+## Donorbox Overlay Setup
+
+The bot also hosts a web overlay for Donorbox progress, checking a specified campaign page automatically.
+
+1. Add a **Browser Source** in OBS
+2. Set the URL to `http://localhost:28080/donorbox`
+3. Set the dimensions as needed for your stream layout
+4. Run the chatbot with the `--url` flag to monitor a specific campaign (e.g. `./stream-chatbot --url https://donorbox.org/your-campaign`). It checks the page every 60 seconds by default.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,20 @@ A Go-powered Twitch chatbot with a music request system and OBS browser overlay.
 
 All music commands use the `!request` prefix:
 
-| Command | Who | Description |
-|---------|-----|-------------|
-| `!request add <query or URL>` | Everyone | Search YouTube and add the top result to the queue |
-| `!request search <query>` | Everyone | Search YouTube and show up to 3 results (use `!request add <number>` to queue one) |
-| `!request add <number>` | Everyone | Add a result from your last search by its number |
-| `!request remove [query\|number]` | Everyone* | Remove a track from the queue by title, index, or most recent. *Non-mods can only remove their own requests |
-| `!request queue` | Everyone | Show the next 3 tracks in the queue |
-| `!request info` | Everyone | Show details about the currently playing track |
-| `!request play` | Mods | Start playback or resume from pause |
-| `!request pause` | Mods | Pause the current track |
-| `!request resume` | Mods | Resume the current track |
-| `!request skip` / `done` | Mods | Skip the current track |
-| `!request limit` | Mods | Toggle rate limiting on/off |
-| `!request autoplay` | Mods | Toggle autoplaying the next song in the queue |
+| Command | Alias | Who | Description |
+|---------|-------|-----|-------------|
+| `!request add <query or URL>` | `!add` | Everyone | Search YouTube and add the top result to the queue |
+| `!request search <query>` | `!search` | Everyone | Search YouTube and show up to 3 results (use `!request add <number>` to queue one) |
+| `!request add <number>` | `!add` | Everyone | Add a result from your last search by its number |
+| `!request remove [query\|number]` | `!remove` | Everyone* | Remove a track from the queue by title, index, or most recent. *Non-mods can only remove their own requests |
+| `!request queue` | `!queue` | Everyone | Show the next 3 tracks in the queue |
+| `!request info` | `!info` | Everyone | Show details about the currently playing track |
+| `!request play` | `!play` | Mods | Start playback or resume from pause |
+| `!request pause` | `!pause` | Mods | Pause the current track |
+| `!request resume` | `!resume` | Mods | Resume the current track |
+| `!request skip` / `done` | `!skip` / `!done` | Mods | Skip the current track |
+| `!request limit` | `!limit` | Mods | Toggle rate limiting on/off |
+| `!request autoplay` | `!autoplay` | Mods | Toggle autoplaying the next song in the queue |
 
 ### General Chat Commands
 

--- a/chatbot/chatbot.go
+++ b/chatbot/chatbot.go
@@ -436,11 +436,22 @@ func Chatbot(TwitchToken string) {
 			}
 		}
 
+		// Handle aliases for !request commands
+		msgTextLower := strings.ToLower(message.Message)
+		requestAliases := []string{"!add", "!search", "!remove", "!play", "!pause", "!resume", "!skip", "!done", "!queue", "!info", "!limit", "!autoplay"}
+		for _, alias := range requestAliases {
+			if strings.HasPrefix(msgTextLower, alias+" ") || msgTextLower == alias {
+				// Replace the alias with !request <command> preserving original casing for arguments
+				message.Message = "!request " + strings.TrimPrefix(alias, "!") + message.Message[len(alias):]
+				break
+			}
+		}
+
 		if strings.HasPrefix(message.Message, "!request ") {
 			log.Println("Detected !request message")
 			args := strings.Fields(strings.TrimSpace(strings.TrimPrefix(message.Message, "!request ")))
 			if len(args) == 0 {
-				client.Say(message.Channel, "Usage: !request <add|search|remove|play|pause|resume|skip|done|queue|info|limit|autoplay>")
+				client.Say(message.Channel, "Usage: !request <add|search|remove|play|pause|resume|skip|done|queue|info|limit|autoplay> (or use !<command> directly)")
 				return
 			}
 			
@@ -675,7 +686,7 @@ func Chatbot(TwitchToken string) {
 				}
 
 			default:
-				msg := "Unknown subcommand. Usage: !request <add|search|remove|play|pause|resume|skip|done|queue|info|limit|autoplay>"
+				msg := "Unknown subcommand. Usage: !request <add|search|remove|play|pause|resume|skip|done|queue|info|limit|autoplay> (or use !<command> directly)"
 				log.Printf("[!request] Response: %s\n", msg)
 				client.Say(message.Channel, msg)
 			}

--- a/chatbot/chatbot.go
+++ b/chatbot/chatbot.go
@@ -440,7 +440,7 @@ func Chatbot(TwitchToken string) {
 			log.Println("Detected !request message")
 			args := strings.Fields(strings.TrimSpace(strings.TrimPrefix(message.Message, "!request ")))
 			if len(args) == 0 {
-				client.Say(message.Channel, "Usage: !request <add|search|remove|play|pause|resume|skip|done|queue|info|limit>")
+				client.Say(message.Channel, "Usage: !request <add|search|remove|play|pause|resume|skip|done|queue|info|limit|autoplay>")
 				return
 			}
 			
@@ -656,8 +656,26 @@ func Chatbot(TwitchToken string) {
 					client.Say(message.Channel, msg)
 				}
 
+			case "autoplay":
+				if isMod {
+					enabled := player.ToggleAutoplay()
+					if enabled {
+						msg := "Autoplay is now ENABLED. The next song will play automatically."
+						log.Printf("[!request autoplay] Response: %s\n", msg)
+						client.Say(message.Channel, msg)
+					} else {
+						msg := "Autoplay is now DISABLED. You will need to use !request play between songs."
+						log.Printf("[!request autoplay] Response: %s\n", msg)
+						client.Say(message.Channel, msg)
+					}
+				} else {
+					msg := "You do not have permission to toggle autoplay."
+					log.Printf("[!request autoplay] Response: %s\n", msg)
+					client.Say(message.Channel, msg)
+				}
+
 			default:
-				msg := "Unknown subcommand. Usage: !request <add|search|remove|play|pause|resume|skip|done|queue|info|limit>"
+				msg := "Unknown subcommand. Usage: !request <add|search|remove|play|pause|resume|skip|done|queue|info|limit|autoplay>"
 				log.Printf("[!request] Response: %s\n", msg)
 				client.Say(message.Channel, msg)
 			}

--- a/chatbot/chatbot.go
+++ b/chatbot/chatbot.go
@@ -607,6 +607,9 @@ func Chatbot(TwitchToken string) {
 			case "skip", "done":
 				if isMod {
 					player.SkipCurrent()
+					if player.GetAutoplay() {
+						player.PlayOrResume()
+					}
 					overlay.BroadcastState()
 					msg := "Current track skipped!"
 					log.Printf("[!request %s] Success: %s\n", subCommand, msg)

--- a/player/queue.go
+++ b/player/queue.go
@@ -32,7 +32,23 @@ var (
 	MaxDurationSeconds = 1200 // 20 minutes
 	CooldownDuration   = 10 * time.Minute
 	RateLimitEnabled   = true
+	AutoplayEnabled    = false
 )
+
+// ToggleAutoplay toggles the autoplay feature.
+func ToggleAutoplay() bool {
+	queueMutex.Lock()
+	defer queueMutex.Unlock()
+	AutoplayEnabled = !AutoplayEnabled
+	return AutoplayEnabled
+}
+
+// GetAutoplay returns whether autoplay is enabled.
+func GetAutoplay() bool {
+	queueMutex.Lock()
+	defer queueMutex.Unlock()
+	return AutoplayEnabled
+}
 
 // ToggleRateLimit toggles the rate limiting feature.
 func ToggleRateLimit() bool {

--- a/web/music_overlay.go
+++ b/web/music_overlay.go
@@ -20,6 +20,17 @@ func MusicOverlay() {
 		w.Write(htmlContent)
 	})
 
+	// Serve the full-screen now playing overlay
+	mux.HandleFunc("/nowplaying", func(w http.ResponseWriter, r *http.Request) {
+		htmlContent, err := content.ReadFile("static/nowplaying.html")
+		if err != nil {
+			http.Error(w, "Error reading embedded HTML file", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.Write(htmlContent)
+	})
+
 	// Serve static JS/CSS
 	mux.Handle("/static/", http.FileServer(http.FS(content)))
 

--- a/web/static/css/nowplaying.css
+++ b/web/static/css/nowplaying.css
@@ -1,0 +1,117 @@
+:root {
+    --primary-color: #0687f5;
+    --bg-dark: rgba(20, 20, 25, 0.85);
+    --text-main: #f5f5f7;
+    --text-secondary: #a1a1aa;
+    --border-radius: 24px;
+}
+
+html, body {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    width: 100vw;
+    height: 100vh;
+    font-family: 'Outfit', sans-serif;
+    color: var(--text-main);
+    overflow: hidden;
+}
+
+.fullscreen-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: var(--bg-dark);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    pointer-events: none;
+    /* Fade out takes 1s */
+    transform: translateY(20px);
+    transition: opacity 1s ease-out, transform 1s ease-out;
+}
+
+.fullscreen-container.show {
+    opacity: 1;
+    transform: translateY(0);
+    /* Fade in takes 0.5s */
+    transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+}
+
+.content {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 60px;
+    padding: 60px;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: var(--border-radius);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 30px 60px rgba(0, 0, 0, 0.4);
+    max-width: 80%;
+}
+
+.thumbnail {
+    width: 400px;
+    height: 400px;
+    object-fit: cover;
+    border-radius: 16px;
+    box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+    border: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.info {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    max-width: 800px;
+}
+
+.now-playing-label {
+    color: var(--primary-color);
+    font-size: 1.5rem;
+    font-weight: 900;
+    letter-spacing: 4px;
+    margin: 0 0 10px 0;
+    text-transform: uppercase;
+}
+
+.title {
+    font-size: 4rem;
+    font-weight: 700;
+    margin: 0 0 10px 0;
+    line-height: 1.1;
+    text-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.artist {
+    font-size: 2rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin: 0 0 30px 0;
+}
+
+.requester-box {
+    display: inline-block;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 10px 24px;
+    border-radius: 30px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.requester {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: #e4e4e7;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}

--- a/web/static/js/music.js
+++ b/web/static/js/music.js
@@ -2,6 +2,7 @@ let ws;
 let currentTrackId = null;
 let ytPlayer = null;
 let lastPausedState = false;
+let playTimeout = null;
 
 // Initialize YouTube IFrame API
 function onYouTubeIframeAPIReady() {
@@ -71,6 +72,9 @@ function handleStateUpdate(state) {
     if (!track) {
         // Nothing actively playing — show "Up Next" or idle message
         stopAllActivePlayers();
+        if (playTimeout) {
+            clearTimeout(playTimeout);
+        }
         currentTrackId = null;
         lastPausedState = false;
 
@@ -101,7 +105,14 @@ function handleStateUpdate(state) {
         document.getElementById('track-requester').innerText = "Requested by " + track.requested_by;
         container.classList.remove('hidden');
 
-        playTrack(track);
+        stopAllActivePlayers();
+        if (playTimeout) {
+            clearTimeout(playTimeout);
+        }
+        
+        playTimeout = setTimeout(() => {
+            playTrack(track);
+        }, 4000);
     }
 
     // Handle pause/resume state changes

--- a/web/static/js/nowplaying.js
+++ b/web/static/js/nowplaying.js
@@ -1,0 +1,82 @@
+let ws;
+let currentTrackId = null;
+let hideTimeout = null;
+
+function connectWebSocket() {
+    ws = new WebSocket("ws://localhost:38080/ws");
+
+    ws.onopen = function() {
+        console.log("Connected to WebSocket");
+    };
+
+    ws.onmessage = function(event) {
+        const msg = JSON.parse(event.data);
+        if (msg.event === "STATE_UPDATE") {
+            handleStateUpdate(msg.data);
+        }
+    };
+
+    ws.onclose = function() {
+        console.log("WebSocket disconnected, retrying in 5s...");
+        setTimeout(connectWebSocket, 5000);
+    };
+}
+
+function handleStateUpdate(state) {
+    const track = state.current_track;
+    const container = document.getElementById('fullscreen-container');
+
+    if (!track) {
+        // Nothing playing, hide immediately without restarting timeout
+        if (container.classList.contains('show')) {
+            hideContainer();
+        }
+        currentTrackId = null;
+        return;
+    }
+
+    if (currentTrackId !== track.id) {
+        currentTrackId = track.id;
+
+        // Update DOM elements
+        // YouTube API returns high-res thumbnails at maxresdefault.jpg or hqdefault.jpg
+        // The bot sends the default url. We can try to upres it.
+        let thumbUrl = track.thumbnail;
+        if (thumbUrl && thumbUrl.includes('default.jpg')) {
+            // Try to use a higher resolution thumbnail
+            thumbUrl = thumbUrl.replace('default.jpg', 'maxresdefault.jpg');
+        }
+
+        document.getElementById('track-thumbnail').src = thumbUrl || '';
+        document.getElementById('track-title').innerText = track.title;
+        document.getElementById('track-artist').innerText = track.artist;
+        document.getElementById('track-requester').innerText = "Requested by " + track.requested_by;
+
+        // Reset any existing hide timeout
+        if (hideTimeout) {
+            clearTimeout(hideTimeout);
+        }
+
+        // Show the container
+        container.classList.add('show');
+
+        // Hide after 3 seconds
+        hideTimeout = setTimeout(() => {
+            hideContainer();
+        }, 3000);
+    }
+}
+
+function hideContainer() {
+    const container = document.getElementById('fullscreen-container');
+    container.classList.remove('show');
+}
+
+// Fallback error handler for high-res thumbnail (maxresdefault might not exist)
+document.getElementById('track-thumbnail').addEventListener('error', function(e) {
+    if (this.src.includes('maxresdefault.jpg')) {
+        this.src = this.src.replace('maxresdefault.jpg', 'hqdefault.jpg');
+    }
+});
+
+connectWebSocket();

--- a/web/static/nowplaying.html
+++ b/web/static/nowplaying.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stream Now Playing Fullscreen Overlay</title>
+    <link rel="stylesheet" href="/static/css/nowplaying.css">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700;900&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div id="fullscreen-container" class="fullscreen-container">
+        <div class="content">
+            <img id="track-thumbnail" src="" alt="Thumbnail" class="thumbnail" />
+            <div class="info">
+                <h2 class="now-playing-label">NOW PLAYING</h2>
+                <h1 id="track-title" class="title">Song Title</h1>
+                <h3 id="track-artist" class="artist">Artist Name</h3>
+                <div class="requester-box">
+                    <span id="track-requester" class="requester">Requested by User</span>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <script src="/static/js/nowplaying.js"></script>
+</body>
+</html>

--- a/web/websocket.go
+++ b/web/websocket.go
@@ -70,8 +70,19 @@ func handleMusicWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if msg.Event == "TRACK_ENDED" {
-			log.Println("Received TRACK_ENDED from overlay, waiting for !request play...")
-			player.ClearCurrent()
+			if player.GetAutoplay() {
+				// Autoplay is on, clear current and try to play next
+				player.ClearCurrent()
+				err := player.PlayOrResume()
+				if err != nil {
+					log.Println("Received TRACK_ENDED (Autoplay ON). Queue empty, waiting.")
+				} else {
+					log.Println("Received TRACK_ENDED (Autoplay ON). Playing next track.")
+				}
+			} else {
+				log.Println("Received TRACK_ENDED from overlay, waiting for !request play...")
+				player.ClearCurrent()
+			}
 			BroadcastState()
 		}
 	}


### PR DESCRIPTION
# Description

> [!NOTE]
> These changes were generated by Google's Antigravity with prompting by @conflabermits and his direct oversight.

This PR introduces several significant quality-of-life improvements to the music request system, including comprehensive command aliasing, an automatic playback queue (autoplay), and a brand new full-screen visual splash overlay for OBS.

## Key Changes

### 🎶 Autoplay Support
- Added a new mod-only toggle command: `!request autoplay` (alias: `!autoplay`). 
- When enabled, the music player will automatically pop the next track off the queue and begin playing it as soon as the current track ends.
- Updated the `!skip` / `!done` commands so that they will automatically advance and play the next track if autoplay is enabled.

### ⌨️ Command Aliases
- Added global shorthand aliases for all music request subcommands to improve chat UX. 
- Viewers can now use `!add`, `!queue`, `!play`, `!skip`, etc., completely bypassing the longer `!request <command>` prefix.

### 📺 Full-Screen "Now Playing" Splash Overlay
- Created a new, optional OBS browser overlay hosted at `http://localhost:38080/nowplaying`.
- This overlay stays 100% transparent until a new track begins, at which point it gracefully fades in a large centered UI featuring the track title, artist, requester, and high-res album art for 3 seconds before fading out.
- The core audio player (`music.js`) has been updated to intentionally delay audio playback by 4 seconds on new tracks. This ensures the audio starts perfectly in sync with the visual splash animation finishing.
- OBS Custom CSS is fully supported; opacity can be dialed down smoothly by adding `opacity: X;` to the body tag in OBS.

### 📝 Documentation & README Overhaul
- Converted command lists into clean, readable Markdown tables.
- Added an explicit "Alias" column to the Music Request Commands table.
- Added setup documentation for the new Full-Screen Splash overlay, including the OBS CSS opacity tweak and notes about the 4-second audio delay.
- Added missing documentation for the Donorbox overlay configuration (`--url` flag).

## Testing Performed
- Verified alias interception correctly preserves casing and arguments (e.g. `!add <URL>`).
- Verified WebSocket state broadcasts trigger the next song correctly via the YouTube IFrame API `TRACK_ENDED` event when `Autoplay` is toggled on.
- Verified CSS transition timing (0.5s fade-in, 1s fade-out) and JS timeout (3s hold, 4s playback delay) on the `/nowplaying` and `/music` overlays.
